### PR TITLE
Run battle

### DIFF
--- a/src/Battlescape/BattlescapeState.h
+++ b/src/Battlescape/BattlescapeState.h
@@ -95,6 +95,8 @@ private:
 	BattleItem *getRightHandItem(BattleUnit *unit);
 	/// Gets the built-in melee weapon of a unit, if any.
 	BattleItem *getSpecialMeleeWeapon(BattleUnit *unit);
+	/// Prints a brief summary of the battle to standard output.
+	void printJsonResults();
 public:
 	/// Selects the next soldier.
 	void selectNextPlayerUnit(bool checkReselect = false, bool setReselect = false, bool checkInventory = false, bool checkFOV = true);

--- a/src/Battlescape/BriefingState.cpp
+++ b/src/Battlescape/BriefingState.cpp
@@ -19,6 +19,7 @@
 #include "BriefingState.h"
 #include "BattlescapeState.h"
 #include "AliensCrashState.h"
+#include "../Engine/Action.h"
 #include "../Engine/Game.h"
 #include "../Engine/LocalizedText.h"
 #include "../Interface/TextButton.h"

--- a/src/Battlescape/BriefingState.cpp
+++ b/src/Battlescape/BriefingState.cpp
@@ -194,7 +194,18 @@ void BriefingState::btnOkClick(Action *)
 		_game->pushState(bs);
 		_game->getSavedGame()->getSavedBattle()->setBattleState(bs);
 		_game->pushState(new NextTurnState(_game->getSavedGame()->getSavedBattle(), bs));
-		_game->pushState(new InventoryState(false, bs));
+		InventoryState *inventoryState = new InventoryState(false, bs);
+		_game->pushState(inventoryState);
+
+		if (Options::runBattle.size() > 0)
+		{
+			SDL_Event ev;
+			ev.type = SDL_MOUSEBUTTONDOWN;
+			ev.button.button = SDL_BUTTON_LEFT;
+
+			Action click = Action(&ev, 0.0, 0.0, 0, 0);
+			inventoryState->btnOkClick(&click);
+		}
 	}
 	else
 	{

--- a/src/Engine/Options.cpp
+++ b/src/Engine/Options.cpp
@@ -104,9 +104,9 @@ void create()
 	_info.push_back(OptionInfo("battleDragScrollButton", &battleDragScrollButton, SDL_BUTTON_MIDDLE));
 	_info.push_back(OptionInfo("dragScrollTimeTolerance", &dragScrollTimeTolerance, 300)); // miliSecond
 	_info.push_back(OptionInfo("dragScrollPixelTolerance", &dragScrollPixelTolerance, 10)); // count of pixels
-	_info.push_back(OptionInfo("battleFireSpeed", &battleFireSpeed, 6));
-	_info.push_back(OptionInfo("battleXcomSpeed", &battleXcomSpeed, 30));
-	_info.push_back(OptionInfo("battleAlienSpeed", &battleAlienSpeed, 30));
+	_info.push_back(OptionInfo("battleFireSpeed", &battleFireSpeed, 20));
+	_info.push_back(OptionInfo("battleXcomSpeed", &battleXcomSpeed, 1));
+	_info.push_back(OptionInfo("battleAlienSpeed", &battleAlienSpeed, 1));
 	_info.push_back(OptionInfo("battleNewPreviewPath", (int*)&battleNewPreviewPath, PATH_NONE)); // requires double-click to confirm moves
 	_info.push_back(OptionInfo("fpsCounter", &fpsCounter, false));
 	_info.push_back(OptionInfo("globeDetail", &globeDetail, true));

--- a/src/Engine/Options.cpp
+++ b/src/Engine/Options.cpp
@@ -145,6 +145,7 @@ void create()
 	_info.push_back(OptionInfo("backgroundMute", &backgroundMute, false));
 	_info.push_back(OptionInfo("randomSeed", &randomSeed, -1));
 	_info.push_back(OptionInfo("turnLimit", &turnLimit, -1));
+	_info.push_back(OptionInfo("runBattle", &runBattle, ""));
 
 	// advanced options
 	_info.push_back(OptionInfo("playIntro", &playIntro, true, "STR_PLAYINTRO", "STR_GENERAL"));

--- a/src/Engine/Options.inc.h
+++ b/src/Engine/Options.inc.h
@@ -9,7 +9,7 @@ OPT bool fullscreen, asyncBlit, playIntro, useScaleFilter, useHQXFilter, useXBRZ
 	autosave, allowResize, borderless, debug, debugUi, fpsCounter, newSeedOnLoad, keepAspectRatio, nonSquarePixelRatio,
 	cursorInBlackBandsInFullscreen, cursorInBlackBandsInWindow, cursorInBlackBandsInBorderlessWindow, maximizeInfoScreens, musicAlwaysLoop, StereoSound, verboseLogging, soldierDiaries, touchEnabled,
 	rootWindowedMode, lazyLoadResources, backgroundMute;
-OPT std::string language, useOpenGLShader;
+OPT std::string language, useOpenGLShader, runBattle;
 OPT KeyboardType keyboardMode;
 OPT SaveSort saveOrder;
 OPT MusicFormat preferredMusic;

--- a/src/Menu/MainMenuState.cpp
+++ b/src/Menu/MainMenuState.cpp
@@ -32,6 +32,7 @@
 #include "OptionsVideoState.h"
 #include "OptionsModsState.h"
 #include "../Engine/Options.h"
+#include "../Engine/Action.h"
 
 namespace OpenXcom
 {
@@ -40,7 +41,18 @@ void GoToMainMenuState::init()
 {
 	Screen::updateScale(Options::geoscapeScale, Options::baseXGeoscape, Options::baseYGeoscape, true);
 	_game->getScreen()->resetDisplay(false);
+	MainMenuState *mainMenuState = new MainMenuState;
 	_game->setState(new MainMenuState);
+
+	if (Options::runBattle.size() > 0)
+	{
+		SDL_Event ev;
+		ev.type = SDL_MOUSEBUTTONDOWN;
+		ev.button.button = SDL_BUTTON_LEFT;
+
+		Action click = Action(&ev, 0.0, 0.0, 0, 0);
+		mainMenuState->btnNewBattleClick(&click);
+	}
 }
 
 /**
@@ -125,7 +137,18 @@ void MainMenuState::btnNewGameClick(Action *)
  */
 void MainMenuState::btnNewBattleClick(Action *)
 {
-	_game->pushState(new NewBattleState);
+	NewBattleState *newBattleState = new NewBattleState;
+	_game->pushState(newBattleState);
+
+	if (Options::runBattle.size() > 0)
+	{
+		SDL_Event ev;
+		ev.type = SDL_MOUSEBUTTONDOWN;
+		ev.button.button = SDL_BUTTON_LEFT;
+
+		Action click = Action(&ev, 0.0, 0.0, 0, 0);
+		newBattleState->btnOkClick(&click);
+	}
 }
 
 /**

--- a/src/Menu/NewBattleState.cpp
+++ b/src/Menu/NewBattleState.cpp
@@ -227,7 +227,14 @@ NewBattleState::NewBattleState() : _craft(0)
 	_btnCancel->onMouseClick((ActionHandler)&NewBattleState::btnCancelClick);
 	_btnCancel->onKeyboardPress((ActionHandler)&NewBattleState::btnCancelClick, Options::keyCancel);
 
-	load();
+	if (Options::runBattle.size() > 0)
+	{
+		load(Options::runBattle);
+	}
+	else
+	{
+		load();
+	}
 }
 
 /**
@@ -544,8 +551,19 @@ void NewBattleState::btnOkClick(Action *)
 
 	_game->popState();
 	_game->popState();
-	_game->pushState(new BriefingState(_craft, base));
+	BriefingState *briefingState = new BriefingState(_craft, base);
+	_game->pushState(briefingState);
 	_craft = 0;
+
+	if (Options::runBattle.size() > 0)
+	{
+		SDL_Event ev;
+		ev.type = SDL_MOUSEBUTTONDOWN;
+		ev.button.button = SDL_BUTTON_LEFT;
+
+		Action click = Action(&ev, 0.0, 0.0, 0, 0);
+		briefingState->btnOkClick(&click);
+	}
 }
 
 /**


### PR DESCRIPTION
Run a battle automatically. Given a `battle.cfg` file, start the battle immediately without requiring any of the usual UI click-throughs and exit the process when the battle is over. Print a short JSON summary of the results to stdout afterwards.