### PR TITLE
Fix bugs with -runBattle option.

### DIFF
--- a/src/Engine/Options.cpp
+++ b/src/Engine/Options.cpp
@@ -1010,8 +1010,14 @@ void writeNode(const YAML::Node& node, YAML::Emitter& emitter)
  */
 bool save(const std::string &filename)
 {
+	if (Options::runBattle.size() > 0)
+	{
+		return true;
+	}
+
 	std::string s = _configFolder + filename + ".cfg";
 	std::ofstream sav(s.c_str());
+
 	if (!sav)
 	{
 		Log(LOG_WARNING) << "Failed to save " << filename << ".cfg";

--- a/src/Menu/NewBattleState.cpp
+++ b/src/Menu/NewBattleState.cpp
@@ -233,7 +233,7 @@ NewBattleState::NewBattleState() : _craft(0)
 	}
 	else
 	{
-		load();
+		load(Options::getMasterUserFolder() + "battle.cfg");
 	}
 }
 
@@ -265,7 +265,7 @@ void NewBattleState::init()
  */
 void NewBattleState::load(const std::string &filename)
 {
-	std::string s = Options::getMasterUserFolder() + filename + ".cfg";
+	std::string s = filename;
 	if (!CrossPlatform::fileExists(s))
 	{
 		initSave();
@@ -470,7 +470,11 @@ void NewBattleState::initSave()
  */
 void NewBattleState::btnOkClick(Action *)
 {
-	save();
+	if (Options::runBattle.size() == 0)
+	{
+		save();
+	}
+
 	if (_missionTypes[_cbxMission->getSelected()] != "STR_BASE_DEFENSE" && _craft->getNumSoldiers() == 0 && _craft->getNumVehicles() == 0)
 	{
 		return;


### PR DESCRIPTION
Two issues:

* It wouldn't find the specified file because it would try to prepend the OpenXcom config directory's name to it.
* We don't want to write the `runBattle` option to the config file when we're done.